### PR TITLE
Fix PyUnicode_AsWideCharString signature

### DIFF
--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -39,7 +39,7 @@ from cvc5 cimport get0, get1, get2
 from cvc5kinds cimport Kind as c_Kind
 
 cdef extern from "Python.h":
-    wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *)
+    wchar_t* PyUnicode_AsWideCharString(object, Py_ssize_t *) except NULL
     object PyUnicode_FromWideChar(const wchar_t*, Py_ssize_t)
     void PyMem_Free(void*)
 


### PR DESCRIPTION
* PyUnicode_AsWideCharString may raise ValueError or MemoryError https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsWideCharString
* https://cython.readthedocs.io/en/stable/src/tutorial/clibraries.html#handling-errors